### PR TITLE
Improve enumeration and function parsing

### DIFF
--- a/Monobjc.Generator.NAnt/Resources/10.8/AppKit.xml
+++ b/Monobjc.Generator.NAnt/Resources/10.8/AppKit.xml
@@ -724,7 +724,7 @@
 				<Change><![CDATA[Properties.First(Name == "ModifierFlags" && Static == True).Type="NSModifierFlags"]]></Change>
 				<Change><![CDATA[Enumerations["NSEventType"].BaseType="NSUInteger"]]></Change>
 				<Change><![CDATA[Enumerations["NSEventMaskFromType"].Name="NSEventMask"]]></Change>
-				<Change><![CDATA[Enumerations["NSEventMask"].BaseType="NSUInteger"]]></Change>
+				<Change><![CDATA[Enumerations["NSEventMask"].BaseType="ulong"]]></Change>
 				<Change><![CDATA[Enumerations["NSEventMask"].Flags=true]]></Change>
 				<Change><![CDATA[Enumerations["Modifier_Flags"].Name="NSModifierFlags"]]></Change>
 				<Change><![CDATA[Enumerations["NSModifierFlags"].BaseType="NSUInteger"]]></Change>
@@ -758,16 +758,8 @@
 					<With><![CDATA[]]></With>
 				</Replace>
 				<Replace>
-					<Source><![CDATA[ = 1ULL << NS]]></Source>
-					<With><![CDATA[ = 1 << NS]]></With>
-				</Replace>
-				<Replace>
-					<Source><![CDATA[ = 1U << NS]]></Source>
-					<With><![CDATA[ = 1 << NS]]></With>
-				</Replace>
-				<Replace>
-					<Source><![CDATA[ = 1 << NS]]></Source>
-					<With><![CDATA[ = 1 << (int) NSEventType.NS]]></With>
+					<Source><![CDATA[ << NS]]></Source>
+					<With><![CDATA[ << (int) NSEventType.NS]]></With>
 				</Replace>
 				<Replace>
 					<Source><![CDATA[NX_TABLET_POINTER_UNKNOWN]]></Source>

--- a/Monobjc.Generator.NAnt/Resources/10.8/DiscRecording.xml
+++ b/Monobjc.Generator.NAnt/Resources/10.8/DiscRecording.xml
@@ -158,14 +158,6 @@
 			</Patch>
 			<Patch type="Generated">
 				<Replace>
-					<Source><![CDATA[/*  ISO-Latin-1,]]></Source>
-					<With><![CDATA[]]></With>
-				</Replace>
-				<Replace>
-					<Source><![CDATA[asofOSX v10.5 theappropriate CD-Textvariantwillnowbeused  */  ]]></Source>
-					<With><![CDATA[]]></With>
-				</Replace>
-				<Replace>
 					<Source><![CDATA[kCFStringEncodingISOLatin1]]></Source>
 					<With><![CDATA[NSStringEncoding.NSISOLatin1StringEncoding]]></With>
 				</Replace>

--- a/Monobjc.Generator.NAnt/Resources/10.8/Foundation.xml
+++ b/Monobjc.Generator.NAnt/Resources/10.8/Foundation.xml
@@ -37,12 +37,6 @@
 				<Change><![CDATA[Enumerations["long"].Name="NSAlignmentOptions"]]></Change>
 				<Change><![CDATA[Enumerations["NSAlignmentOptions"].BaseType="ulong"]]></Change>
 			</Patch>
-			<Patch type="Generated">
-				<Replace>
-					<Source><![CDATA[UL <<]]></Source>
-					<With><![CDATA[ <<]]></With>
-				</Replace>
-			</Patch>
 		</Type>
 		<Type name="FoundationFramework.DataTypes">
 			<File>Cocoa/Reference/Foundation/Miscellaneous/Foundation_DataTypes/Reference/reference.html</File>
@@ -653,12 +647,6 @@
 				<Change><![CDATA[Enumerations["NSDataWritingOptions"].Values.Set("NSAtomicWrite", "<EnumerationValue><Summary><Line>Deprecated name for NSDataWritingAtomic.</Line></Summary><MinAvailability>OS X v10.4</MinAvailability><Name>NSAtomicWrite</Name><Value>1U &lt;&lt; 0</Value></EnumerationValue>")]]></Change>
 				<Change><![CDATA[Enumerations["Legacy_Writing_Options"].Generate=false]]></Change>
 			</Patch>
-			<Patch type="Generated">
-				<Replace>
-					<Source><![CDATA[UL <<]]></Source>
-					<With><![CDATA[ <<]]></With>
-				</Replace>
-			</Patch>
 		</Class>
 		<Class name="NSData.Deprecated">
 			<File>Cocoa/Reference/Foundation/Classes/NSData_Class/DeprecationAppendix/AppendixADeprecatedAPI.html</File>
@@ -866,16 +854,6 @@
 				<Change><![CDATA[Properties["Delegate"].Type="Id"]]></Change>
 				<Change><![CDATA[Properties["UbiquityIdentityToken"].Type="Id"]]></Change>
 			</Patch>
-			<Patch type="Generated">
-				<Replace>
-					<Source><![CDATA[UL <<]]></Source>
-					<With><![CDATA[ <<]]></With>
-				</Replace>
-				<Replace>
-					<Source><![CDATA[L <<]]></Source>
-					<With><![CDATA[ <<]]></With>
-				</Replace>
-			</Patch>
 		</Class>
 		<Class name="NSFileManager.Deprecated">
 			<File>Cocoa/Reference/Foundation/Classes/NSFileManager_Class/DeprecationAppendix/AppendixADeprecatedAPI.html</File>
@@ -1025,12 +1003,6 @@
 		</Class>
 		<Class name="NSJSONSerialization">
 			<File>Foundation/Reference/NSJSONSerialization_Class/Reference/Reference.html</File>
-			<Patch type="Generated">
-				<Replace>
-					<Source><![CDATA[UL <<]]></Source>
-					<With><![CDATA[ <<]]></With>
-				</Replace>
-			</Patch>
 		</Class>
 		<Class name="NSKeyedArchiver">
 			<File>Cocoa/Reference/Foundation/Classes/NSKeyedArchiver_Class/Reference/Reference.html</File>
@@ -1443,12 +1415,6 @@
 				<Change><![CDATA[Enumerations["Memory_and_Personality_Options"].Name="NSPointerFunctionsOptions"]]></Change>
 				<Change><![CDATA[Enumerations["NSPointerFunctionsOptions"].BaseType="NSUInteger"]]></Change>
 			</Patch>
-			<Patch type="Generated">
-				<Replace>
-					<Source><![CDATA[UL <<]]></Source>
-					<With><![CDATA[ <<]]></With>
-				</Replace>
-			</Patch>
 		</Class>
 		<Class name="NSPort">
 			<File>Cocoa/Reference/Foundation/Classes/NSPort_Class/Reference/Reference.html</File>
@@ -1825,12 +1791,6 @@
 				<Change><![CDATA[Enumerations["String_Enumeration_Options"].Name="NSStringEnumerationOptions"]]></Change>
 				<Change><![CDATA[Enumerations["NSStringEnumerationOptions"].BaseType="NSUInteger"]]></Change>
 			</Patch>
-			<Patch type="Generated">
-				<Replace>
-					<Source><![CDATA[UL <<]]></Source>
-					<With><![CDATA[ <<]]></With>
-				</Replace>
-			</Patch>
 		</Class>
 		<Class name="NSString.Deprecated">
 			<File>Cocoa/Reference/Foundation/Classes/NSString_Class/DeprecationAppendix/AppendixADeprecatedAPI.html</File>
@@ -1945,12 +1905,6 @@
 				<Change><![CDATA[Methods["InitByResolvingBookmarkDataOptionsRelativeToURLBookmarkDataIsStaleError"].Parameters["isStale"].IsOut=true]]></Change>
 				<Change><![CDATA[Methods["InitFileURLWithPath"].GenerateConstructor=false]]></Change>
 				<Change><![CDATA[Methods["WriteBookmarkDataToURLOptionsError"].Parameters["options"].Type="NSURLBookmarkCreationOptions"]]></Change>
-			</Patch>
-			<Patch type="Generated">
-				<Replace>
-					<Source><![CDATA[UL <<]]></Source>
-					<With><![CDATA[ <<]]></With>
-				</Replace>
 			</Patch>
 		</Class>
 		<Class name="NSURL.Deprecated">
@@ -2121,12 +2075,6 @@
 				<Change><![CDATA[Enumerations["NSXMLNodeOptions"].BaseType="NSUInteger"]]></Change>
 				<Change><![CDATA[Enumerations["NSXMLNodeOptions"].Flags=true]]></Change>
 			</Patch>
-			<Patch type="Generated">
-				<Replace>
-					<Source><![CDATA[UL <<]]></Source>
-					<With><![CDATA[ <<]]></With>
-				</Replace>
-			</Patch>
 		</Class>
 		<Class name="NSXMLParser">
 			<File>Cocoa/Reference/Foundation/Classes/NSXMLParser_Class/Reference/Reference.html</File>
@@ -2139,7 +2087,7 @@
 			<File>Foundation/Reference/NSXPCConnection_reference/translated_content/NSXPCConnection.html</File>
 			<Patch type="Generated">
 				<Replace>
-					<Source><![CDATA[UL),]]></Source>
+					<Source><![CDATA[U),]]></Source>
 					<With><![CDATA[),]]></With>
 				</Replace>
 			</Patch>

--- a/Monobjc.Generator/Model/Entities/MethodEntity.cs
+++ b/Monobjc.Generator/Model/Entities/MethodEntity.cs
@@ -138,11 +138,11 @@ namespace Monobjc.Tools.Generator.Model
 		/// <value><c>true</c> if this instance is a getter; otherwise, <c>false</c>.</value>
 		public bool IsConstructor {
 			get {
-				bool result = this.GenerateConstructor;
-				result &= !this.Static;
-				result &= (this.Name.Length > 4);
-				result &= this.Name.StartsWith ("Init", StringComparison.OrdinalIgnoreCase);
-				return result;
+				return this.GenerateConstructor
+					&& !this.Static
+					&& this.Name.Length > 4
+					&& this.Name.StartsWith ("Init", StringComparison.OrdinalIgnoreCase) 
+					&& char.IsUpper(this.Name[4]); // to avoid words like "Initial"
 			}
 		}
 

--- a/Monobjc.Generator/Parsers/Xhtml/Classic/XhtmlClassicFunctionParser.cs
+++ b/Monobjc.Generator/Parsers/Xhtml/Classic/XhtmlClassicFunctionParser.cs
@@ -93,7 +93,11 @@ namespace Monobjc.Tools.Generator.Parsers.Xhtml.Classic
 				this.Logger.WriteLine ("SKIPPING define statement: " + name);
 				return null;
 			}
-			
+			if (!signature.Contains ("(")) { // e.g. NS_DURING
+				this.Logger.WriteLine ("SKIPPING non-function statement: " + name);
+				return null;
+			}
+
 			// Trim down signature
 			while (signature.IndexOf("  ") != -1) {
 				signature = signature.Replace ("  ", " ");
@@ -133,8 +137,10 @@ namespace Monobjc.Tools.Generator.Parsers.Xhtml.Classic
 			}
 
 			String returnType = signature.Substring (0, pos).Trim ();
-			String parameters = signature.Substring (pos + name.Length).Trim ();
-			parameters = parameters.Trim (';', '(', ')');
+			int paramsIndex = pos + name.Length;
+			int paramsLength = signature.IndexOf(')') + 1 - paramsIndex; // Stop before getting to function body
+			String parameters = signature.Substring (paramsIndex, paramsLength).Trim ();
+			parameters = parameters.Trim (';', '(', ')').Trim();
 			if (parameters != "void") {
 				foreach (string parameter in parameters.Split(new []{','}, StringSplitOptions.RemoveEmptyEntries)) {
 					String parameterType = "NOTYPE";

--- a/Monobjc.Generator/Parsers/Xhtml/Cocoa/XhtmlCocoaFunctionParser.cs
+++ b/Monobjc.Generator/Parsers/Xhtml/Cocoa/XhtmlCocoaFunctionParser.cs
@@ -86,6 +86,10 @@ namespace Monobjc.Tools.Generator.Parsers.Xhtml.Cocoa
 				this.Logger.WriteLine ("SKIPPING define statement: " + name);
 				return null;
 			}
+			if (!signature.Contains ("(")) { // e.g. NS_DURING
+				this.Logger.WriteLine ("SKIPPING non-function statement: " + name);
+				return null;
+			}
 
 			// Trim down signature
 			while (signature.IndexOf("  ") != -1) {
@@ -101,8 +105,10 @@ namespace Monobjc.Tools.Generator.Parsers.Xhtml.Cocoa
 				return null;
 			}
 			String returnType = signature.Substring (0, pos).Trim ();
-			String parameters = signature.Substring (pos + name.Length).Trim ();
-			parameters = parameters.Trim (';', '(', ')');
+			int paramsIndex = pos + name.Length;
+			int paramsLength = signature.IndexOf(')') + 1 - paramsIndex; // Stop before getting to function body
+			String parameters = signature.Substring (paramsIndex, paramsLength).Trim ();
+			parameters = parameters.Trim (';', '(', ')').Trim();
 			if (parameters != "void") {
 				foreach (string parameter in parameters.Split(new []{','}, StringSplitOptions.RemoveEmptyEntries)) {
 					String parameterType = "NOTYPE";

--- a/Monobjc.Generator/Parsers/Xhtml/Cocoa/XhtmlCocoaMethodParser.cs
+++ b/Monobjc.Generator/Parsers/Xhtml/Cocoa/XhtmlCocoaMethodParser.cs
@@ -116,6 +116,11 @@ namespace Monobjc.Tools.Generator.Parsers.Xhtml.Cocoa
                 parameterEntity.Name = parameterNamesEnumerator.Current.Trim();
                 methodEntity.Parameters.Add(parameterEntity);
 
+				// Correct names that end in a single period
+				if (parameterEntity.Name.EndsWith(".") && !parameterEntity.Name.EndsWith("..")) {
+					parameterEntity.Name = parameterEntity.Name.Substring(0, parameterEntity.Name.Length - 1);
+				}
+
                 // Handle variadic parameters
                 Match r = VARARG_PARAMETER_REGEX.Match (parameterEntity.Name);
                 if (r.Success) 

--- a/Monobjc.Generator/Parsers/Xhtml/XhtmlBaseParser.cs
+++ b/Monobjc.Generator/Parsers/Xhtml/XhtmlBaseParser.cs
@@ -31,9 +31,10 @@ namespace Monobjc.Tools.Generator.Parsers.Xhtml
 	/// </summary>
 	public abstract class XhtmlBaseParser : BaseParser
 	{
-		protected static readonly Regex ENUMERATION_REGEX = new Regex (@"(typedef )?enum( ?[_A-z]+)? ?\{(.+)\};?( ?typedef)?( ?[A-z0-9_]+ ?)?([A-z]+)?");
+		protected static readonly Regex ENUMERATION_REGEX = new Regex (@"(typedef\s)?enum(\s?[_A-z]+)?\s*?\{(.+)\};?(\s?typedef)?(\s?[A-z0-9_]+\s?)?([A-z]+)?", RegexOptions.Singleline);
 		protected static readonly Regex CONSTANT_REGEX = new Regex (@"(id ?|unsigned ?|double ?|float ?\*?|NSString ?\*? ?|CFStringRef ?|CIFormat|CATransform3D|CLLocationDistance ?)([A-z0-9]+)$");
 		protected static readonly Regex PARAMETER_REGEX = new Regex (@"(const )?([0-9A-z]+ ?\*{0,2} ?)([0-9A-z]+)");
+		protected static readonly Regex COMMENTS_REGEX = new Regex (@"(/\*(.|[\r\n])*?\*/)|(//.*)", RegexOptions.Singleline);
 
 		/// <summary>
 		///   Initializes a new instance of the <see cref = "XhtmlBaseParser" /> class.
@@ -74,6 +75,12 @@ namespace Monobjc.Tools.Generator.Parsers.Xhtml
 
 				values = r.Groups [3].Value.Trim ();
 
+				// Make sure the values declaration didn't
+				// contain multiple enums like CFSocketStream 
+				// by checking for '{'.
+				if (values.Contains('{'))
+					return false;
+
 				// Name can be before enumeration values
 				if (!String.IsNullOrEmpty (v5) && !String.IsNullOrEmpty (v6)) {
 					type = v5;
@@ -97,6 +104,9 @@ namespace Monobjc.Tools.Generator.Parsers.Xhtml
 				bool isBlock;
 				type = this.TypeManager.ConvertType (type, out isOut, out isByRef, out isBlock, this.Logger);
 
+				// Clean values
+				CleanEnumValues (name, ref values);
+
 				//this.Logger.WriteLine("Enumeration found '{0}' of type '{1}'", name, type);
 
 				return true;
@@ -105,6 +115,111 @@ namespace Monobjc.Tools.Generator.Parsers.Xhtml
 			this.Logger.WriteLine ("FAILED to parse enum '{0}'", declaration);
 
 			return false;
+		}
+
+		/// <summary>
+		/// Cleans the enum values section by stripping comments
+		/// and formatting in preparation for key/value parsing.
+		/// </summary>
+		/// <param name="name">Name of enum.</param>
+		/// <param name="values">Values to clean.</param>
+		private static void CleanEnumValues (String name, ref String values)
+		{
+			// Rejoin wrapped lines that had no comma (unless that would make for two = assignements).
+			// See UIInterfaceOrientationMask. Single line format is required for key / value parsing later.
+			//
+			// Example:
+			//
+			// enum {
+			//   v1
+			// = 1,
+			//   v2 = 2,
+			// }
+			//
+			// enum {
+			//   v1 = 1,
+			//   v2 = 2,
+			// }
+			var lines = values.Split(new [] { '\n' }, StringSplitOptions.RemoveEmptyEntries);
+			values = string.Empty;
+			for (int i = 0; i < lines.Length; ++i) {
+				var line = lines[i];
+				values += line;
+				if (line.Contains(',')) {
+					values += "\n";
+				} else if (line.Contains("=") && i + 1 < lines.Length && lines[i + 1].Contains("=")) {
+					values += "\n";
+				}
+			}
+
+			// Process lines with a comment adjacent to a value (like UIBarButtonSystem).
+			// This must be performed before comment stripping to catch values.
+			//
+			// Example:
+			//
+			// enum {
+			//  v1, // c1v2 // c2
+			// }
+			//
+			// enum {
+			//   v1, /* c1 */
+			//   v2, /* c2 */
+			// }
+			lines = values.Split(new [] { '\n' }, StringSplitOptions.RemoveEmptyEntries);
+			values = string.Empty;
+			foreach (string line in lines) {
+				// Split on each type name
+				var nameSplit = line.Split(new string[] { name }, StringSplitOptions.None);
+				// If there is a comment and more than one reference to the type
+				if (line.Contains("//") && nameSplit.Length - 1 > 1) {
+					// Keep the first reference as is or ignore it
+					if (!string.IsNullOrEmpty(nameSplit[0].Trim()) && nameSplit[0].Contains(name))
+						values += name + nameSplit[0] + "\n";
+					// Add a newline before each type reference
+					for (int i = 1; i < nameSplit.Length; ++i) {
+						if (!string.IsNullOrEmpty(nameSplit[i].Trim())) {
+							// Convert comment to format supporting post-comma
+							nameSplit[i] = nameSplit[i].Replace("//", "/*").Trim();
+							if (!values.EndsWith("\n"))
+								values += "\n";
+							values += name + nameSplit[i];
+							if (nameSplit[i].Contains("/*"))
+								values += " */";
+							values += "\n";
+						}
+					}
+				} else {
+					values += line.Trim() + "\n";
+				}
+			}
+
+			// Strip all comments before next phase so that commas in comments
+			// or before comments don't throw off the new lines. Comments in
+			// keys also interfere with doc generation, and comments in values
+			// can interfere with comma placement during generation. It's best
+			// to just strip them.
+			values = COMMENTS_REGEX.Replace(values, "");
+
+			// Split lines with commas (like NSCalendarUnit, UIPrintInfoOutputType) not 
+			// between comments (like CDTextEncodings). Comments must be stripped first.
+			//
+			// Example:
+			//
+			// enum { v1, v2, /* A comment, here */ v3 }
+			//
+			// enum {
+			//   v1,
+			//   v2,
+			//   v3
+			// }
+			lines = values.Split (new []{'\n'}, StringSplitOptions.RemoveEmptyEntries);
+			values = string.Empty;
+			foreach (string line in lines) {
+				var lineSplit = line.Trim().Split(new []{','}, StringSplitOptions.RemoveEmptyEntries);
+				foreach (var l in lineSplit) {
+					values += l + ",\n";
+				}
+			}
 		}
 
 		/// <summary>

--- a/Monobjc.Generator/Utilities/Extensions.cs
+++ b/Monobjc.Generator/Utilities/Extensions.cs
@@ -94,6 +94,22 @@ namespace Monobjc.Tools.Generator.Utilities
             return str.Trim();
         }
 
+		/// <summary>
+		///   Trims all the leading and tailing spaces, as well as double space characters.
+		/// </summary>
+		/// <param name = "element">The element.</param>
+		/// <returns>A trimmed string value.</returns>
+		public static String TrimSpaces(this XElement element)
+		{
+			if (element == null)
+			{
+				return String.Empty;
+			}
+			String str = element.Value;
+			str = str.Replace("  ", " ");
+			return str.Trim();
+		}
+
         /// <summary>
         ///   Trims all the leading and tailing spaces, as well as the the CR-LF characters.
         /// </summary>


### PR DESCRIPTION
1. Determine enum base type by values containing L, UL, ULL.
2. Downgrade native to managed qualifiers (ULL -> UL, etc.)
3. Don't strip LFs from enums during conversion.
4. Convert comments to /\* */ format to facilitate comma generation.
5. Skip comment-only lines.
6. Update RegEx to improve enum matching.
7. Remove some now obsolete definitions from the model.
8. Auto-Skip functions that contain no () sig
9. Limit function parameter area to () to skip function body.
10. Treat only methods named "InitSomething" as constructors. Types like UICollectionViewLayout have methods that begin with "Initial" that are not constructors.
