### PR TITLE
Fix Game Kit blocks that reference UIImage.

### DIFF
--- a/Monobjc.Generator.NAnt/Resources/10.8/GameKit.xml
+++ b/Monobjc.Generator.NAnt/Resources/10.8/GameKit.xml
@@ -21,6 +21,7 @@
 				<Change><![CDATA[Properties["Image"].Type="NSImage"]]></Change>
 				<Change><![CDATA[Properties["IncompleteAchievementImage"].Type="NSImage"]]></Change>
 				<Change><![CDATA[Properties["PlaceholderCompletedAchievementImage"].Type="NSImage"]]></Change>
+				<Change><![CDATA[Methods["LoadImageWithCompletionHandler"].Parameters["completionHandler"].Type="Action<NSImage, NSError>"]]></Change>
 			</Patch>
 		</Class>
 		<Class name="GKAchievementViewController">
@@ -89,6 +90,9 @@
 		</Class>
 		<Class name="GKPlayer">
 			<File>GameKit/Reference/GKPlayer_Ref/Reference/Reference.html</File>
+            <Patch type="Model">
+				<Change><![CDATA[Methods["LoadPhotoForSizeWithCompletionHandler"].Parameters["completionHandler"].Type="Action<NSImage, NSError>"]]></Change>
+            </Patch>
 		</Class>
 		<Class name="GKScore">
 			<File>GameKit/Reference/GKScore_Ref/Reference/Reference.html</File>

--- a/Monobjc.Generator.NAnt/Resources/Mappings.xml
+++ b/Monobjc.Generator.NAnt/Resources/Mappings.xml
@@ -423,7 +423,7 @@
     <Mapping type="SecTrustedApplicationRef">IntPtr</Mapping>
     <Mapping type="TISInputSourceRef">IntPtr</Mapping>
     <Mapping type="Track">IntPtr</Mapping>
-    <Mapping type="UIImage *">NSImage</Mapping>
+    <Mapping type="UIImage *">UIImage</Mapping>
     <Mapping type="UInt16">ushort</Mapping>
     <Mapping type="UInt32 *">ref:uint</Mapping>
     <Mapping type="UInt32">uint</Mapping>
@@ -576,8 +576,8 @@
     <Mapping type="void (^)(NSURL *newURL1, NSURL *newURL2)"><![CDATA[block:Action<NSURL, NSURL>]]></Mapping>
     <Mapping type="void (^)(NSURLResponse*, NSData*, NSError*)"><![CDATA[block:Action<NSURLResponse, NSData, NSError>]]></Mapping>
     <Mapping type="void (^)(NSWindow *, NSError *)"><![CDATA[block:Action<NSWindow, NSError>]]></Mapping>
-    <Mapping type="void (^)(UIImage *image, NSError *error)"><![CDATA[block:Action<NSImage, NSError>]]></Mapping>
-    <Mapping type="void (^)(UIImage *photo, NSError *error)"><![CDATA[block:Action<NSImage, NSError>]]></Mapping>
+    <Mapping type="void (^)(UIImage *image, NSError *error)"><![CDATA[block:Action<UIImage, NSError>]]></Mapping>
+    <Mapping type="void (^)(UIImage *photo, NSError *error)"><![CDATA[block:Action<UIImage, NSError>]]></Mapping>
     <Mapping type="void (^)(id key, id obj, BOOL *stop)"><![CDATA[block:Action_Id_Id_out_bool]]></Mapping>
     <Mapping type="void (^)(id obj, BOOL *stop)"><![CDATA[block:Action_Id_out_bool]]></Mapping>
     <Mapping type="void (^)(id obj, NSUIntegeridx, BOOL *stop)"><![CDATA[block:Action_Id_NSUInteger_out_bool]]></Mapping>


### PR DESCRIPTION
Previously mappings.xml was used to convert these erroneous handlers by changing UIImage to NSImage. This can't be done in mappings.xml which is used by iOS as well.
